### PR TITLE
Only sort list after holding down touch

### DIFF
--- a/www_src/components/media-playlist/index.tsx
+++ b/www_src/components/media-playlist/index.tsx
@@ -55,7 +55,7 @@ export const MediaPlaylist = () => {
           <div className="text-sm opacity-50">{state.songs.length} songs</div>
         </div>
       </div>
-      <ReactSortable list={state.songs} setList={sortPlaylistHandler}>
+      <ReactSortable delayOnTouchOnly delay={100} list={state.songs} setList={sortPlaylistHandler}>
         {state.songs.map((song, i) => {
           const isCurrent = state.player?.currentSong?.id === song.id;
           return (


### PR DESCRIPTION
On real touch device, whenever we want to scroll the list, react-sortable kicks in instead so we can not scroll